### PR TITLE
feat: add borsh schema to sign transaction

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@metamask/providers": "^9.0.0",
+    "borsh": "^1.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-is": "^18.2.0",

--- a/packages/site/src/components/Sovereign.tsx
+++ b/packages/site/src/components/Sovereign.tsx
@@ -1,8 +1,15 @@
 import React, { useState } from 'react';
+import { Schema } from 'borsh';
 import { defaultSnapOrigin } from '../config';
 import { ExecuteButton } from './Buttons';
 
-type MethodSelectorState = `signMessage` | `getPublicKey`;
+const callMessageSchema: Schema = {
+  struct: {
+    message: 'string',
+  },
+};
+
+type MethodSelectorState = `signTransaction` | `getPublicKey`;
 type CurveSelectorState = `secp256k1` | `ed25519`;
 
 type SovereignState = {
@@ -16,7 +23,7 @@ type SovereignState = {
 
 export const Sovereign = () => {
   const initialState: SovereignState = {
-    method: `signMessage`,
+    method: `signTransaction`,
     curve: `secp256k1`,
     keyId: 0,
     message: 'Some signature message...',
@@ -36,7 +43,7 @@ export const Sovereign = () => {
             })
           }
         >
-          <option value="signMessage">Sign Message</option>
+          <option value="signTransaction">Sign Transaction</option>
           <option value="getPublicKey">Get Public Key</option>
         </select>
       </div>
@@ -77,7 +84,7 @@ export const Sovereign = () => {
       <div>Signature message:</div>
       <div>
         <textarea
-          disabled={state.method !== `signMessage`}
+          disabled={state.method !== `signTransaction`}
           value={state.message}
           onChange={(ev) =>
             setState({
@@ -99,11 +106,14 @@ export const Sovereign = () => {
             path.push(keyId.toString());
 
             let params;
-            if (method === `signMessage`) {
+            if (method === `signTransaction`) {
               params = {
                 path,
                 curve,
-                message: message || '',
+                schema: callMessageSchema,
+                transaction: {
+                  message: message || '',
+                },
               };
             } else {
               params = {

--- a/packages/site/src/components/Sovereign.tsx
+++ b/packages/site/src/components/Sovereign.tsx
@@ -17,6 +17,7 @@ type SovereignState = {
   curve: CurveSelectorState;
   keyId: number;
   message?: string;
+  nonce?: number;
   request?: string;
   response?: string;
 };
@@ -27,6 +28,7 @@ export const Sovereign = () => {
     curve: `secp256k1`,
     keyId: 0,
     message: 'Some signature message...',
+    nonce: 0,
   };
   const [state, setState] = useState(initialState);
 
@@ -97,10 +99,29 @@ export const Sovereign = () => {
           cols={40}
         />
       </div>
+      <div>Nonce:</div>
+      <div>
+        <input
+          type="number"
+          value={state.nonce}
+          onChange={(ev) => {
+            const { value } = ev.target;
+
+            // Allow only positive integers (whole numbers greater than or equal to zero)
+            const regex = /^[0-9\b]+$/u; // Allows digits only
+            if (value === '' || regex.test(value)) {
+              setState({
+                ...state,
+                nonce: parseInt(value, 10),
+              });
+            }
+          }}
+        />
+      </div>
       <div>
         <ExecuteButton
           onClick={async () => {
-            const { method, curve, keyId, message } = state;
+            const { method, curve, keyId, message, nonce } = state;
 
             const path = ['m', "44'", "1551'"];
             path.push(keyId.toString());
@@ -114,6 +135,7 @@ export const Sovereign = () => {
                 transaction: {
                   message: message || '',
                 },
+                nonce,
               };
             } else {
               params = {

--- a/packages/site/src/components/Sovereign.tsx
+++ b/packages/site/src/components/Sovereign.tsx
@@ -17,7 +17,6 @@ type SovereignState = {
   curve: CurveSelectorState;
   keyId: number;
   message?: string;
-  nonce?: number;
   request?: string;
   response?: string;
 };
@@ -28,7 +27,6 @@ export const Sovereign = () => {
     curve: `secp256k1`,
     keyId: 0,
     message: 'Some signature message...',
-    nonce: 0,
   };
   const [state, setState] = useState(initialState);
 
@@ -99,29 +97,10 @@ export const Sovereign = () => {
           cols={40}
         />
       </div>
-      <div>Nonce:</div>
-      <div>
-        <input
-          type="number"
-          value={state.nonce}
-          onChange={(ev) => {
-            const { value } = ev.target;
-
-            // Allow only positive integers (whole numbers greater than or equal to zero)
-            const regex = /^[0-9\b]+$/u; // Allows digits only
-            if (value === '' || regex.test(value)) {
-              setState({
-                ...state,
-                nonce: parseInt(value, 10),
-              });
-            }
-          }}
-        />
-      </div>
       <div>
         <ExecuteButton
           onClick={async () => {
-            const { method, curve, keyId, message, nonce } = state;
+            const { method, curve, keyId, message } = state;
 
             const path = ['m', "44'", "1551'"];
             path.push(keyId.toString());
@@ -135,7 +114,6 @@ export const Sovereign = () => {
                 transaction: {
                   message: message || '',
                 },
-                nonce,
               };
             } else {
               params = {

--- a/packages/site/tsconfig.json
+++ b/packages/site/tsconfig.json
@@ -5,7 +5,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "experimentalDecorators": true
   },
   "include": ["src"]
 }

--- a/packages/snap/README.md
+++ b/packages/snap/README.md
@@ -45,6 +45,7 @@ Will emit a confirmation dialog for the user.
 - `curve`: The curve of the public key (`secp256k1` or `ed25519`).
 - `schema`: A [borsh](https://www.npmjs.com/package/borsh) schema for the transaction.
 - `transaction`: A transaction to be serialized using the provided schema. The signature will be performed over the serialized transaction.
+- `nonce`: An unsigned 64-bits number to be appended to the serialized transaction.
 
 ##### Example
 
@@ -90,12 +91,13 @@ const response = request({
         amount: 1582,
       },
     },
+    nonce: 0,
   },
 });
 
 if (
   !response ===
-  '0xfd2e4b23a3e3f498664af355b341e833324276270a13f9647dd1f043248f92fccaa037d4cfc9d23f13a295f7d505ee13afb2b10cea548890678f9002947cbb0a'
+  '0xe563b3d772572e57bff43e31e449dbc8e98f7580fea10b2ad1ad8278b3edcf5ff5b3a24b85cef3192fcd70452c58e7c968e500da9e290aefadf5ef22a4efbf0d',
 ) {
   throw new Error('Invalid signature');
 }

--- a/packages/snap/README.md
+++ b/packages/snap/README.md
@@ -45,7 +45,6 @@ Will emit a confirmation dialog for the user.
 - `curve`: The curve of the public key (`secp256k1` or `ed25519`).
 - `schema`: A [borsh](https://www.npmjs.com/package/borsh) schema for the transaction.
 - `transaction`: A transaction to be serialized using the provided schema. The signature will be performed over the serialized transaction.
-- `nonce`: An unsigned 64-bits number to be appended to the serialized transaction.
 
 ##### Example
 
@@ -91,13 +90,12 @@ const response = request({
         amount: 1582,
       },
     },
-    nonce: 0,
   },
 });
 
 if (
   !response ===
-  '0xe563b3d772572e57bff43e31e449dbc8e98f7580fea10b2ad1ad8278b3edcf5ff5b3a24b85cef3192fcd70452c58e7c968e500da9e290aefadf5ef22a4efbf0d',
+  '0xfd2e4b23a3e3f498664af355b341e833324276270a13f9647dd1f043248f92fccaa037d4cfc9d23f13a295f7d505ee13afb2b10cea548890678f9002947cbb0a'
 ) {
   throw new Error('Invalid signature');
 }

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -33,6 +33,7 @@
     "@metamask/utils": "^8.1.0",
     "@noble/ed25519": "^1.6.0",
     "@noble/secp256k1": "^1.7.1",
+    "borsh": "^1.0.0",
     "buffer": "^6.0.3"
   },
   "devDependencies": {

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -34,7 +34,8 @@
     "@noble/ed25519": "^1.6.0",
     "@noble/secp256k1": "^1.7.1",
     "borsh": "^1.0.0",
-    "buffer": "^6.0.3"
+    "buffer": "^6.0.3",
+    "int64-buffer": "^1.0.1"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -34,8 +34,7 @@
     "@noble/ed25519": "^1.6.0",
     "@noble/secp256k1": "^1.7.1",
     "borsh": "^1.0.0",
-    "buffer": "^6.0.3",
-    "int64-buffer": "^1.0.1"
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/Sovereign-Labs/sov-snap.git"
   },
   "source": {
-    "shasum": "WZco6V2pvJMpitcOysOcWYoVpGTBAn7cSdHRGM6MRu0=",
+    "shasum": "wOP1ZGD2ciBIysiXTThBibt0cTkaxNKbsFCLXk+Si/c=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/Sovereign-Labs/sov-snap.git"
   },
   "source": {
-    "shasum": "wOP1ZGD2ciBIysiXTThBibt0cTkaxNKbsFCLXk+Si/c=",
+    "shasum": "M4WoRFL+SjnLWRKANC/7e5s/+nwPabd2hvVY77TCck8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/Sovereign-Labs/sov-snap.git"
   },
   "source": {
-    "shasum": "ffF94Uc3L8/OZ4qDYWUAWbUDSs/a4v69Bg24WiT3Mvc=",
+    "shasum": "WZco6V2pvJMpitcOysOcWYoVpGTBAn7cSdHRGM6MRu0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/index.test.ts
+++ b/packages/snap/src/index.test.ts
@@ -84,6 +84,7 @@ describe('onRpcRequest', () => {
               payload: Array(176).fill(5),
             },
           },
+          nonce: 26,
         },
       });
 
@@ -114,6 +115,7 @@ describe('onRpcRequest', () => {
               amount: 1582,
             },
           },
+          nonce: 0,
         },
       });
 
@@ -122,7 +124,7 @@ describe('onRpcRequest', () => {
       await ui.ok();
 
       expect(await response).toRespondWith(
-        '0xfd2e4b23a3e3f498664af355b341e833324276270a13f9647dd1f043248f92fccaa037d4cfc9d23f13a295f7d505ee13afb2b10cea548890678f9002947cbb0a',
+        '0xe563b3d772572e57bff43e31e449dbc8e98f7580fea10b2ad1ad8278b3edcf5ff5b3a24b85cef3192fcd70452c58e7c968e500da9e290aefadf5ef22a4efbf0d',
       );
 
       await close();

--- a/packages/snap/src/index.test.ts
+++ b/packages/snap/src/index.test.ts
@@ -84,7 +84,6 @@ describe('onRpcRequest', () => {
               payload: Array(176).fill(5),
             },
           },
-          nonce: 26,
         },
       });
 
@@ -115,7 +114,6 @@ describe('onRpcRequest', () => {
               amount: 1582,
             },
           },
-          nonce: 0,
         },
       });
 
@@ -124,7 +122,7 @@ describe('onRpcRequest', () => {
       await ui.ok();
 
       expect(await response).toRespondWith(
-        '0xe563b3d772572e57bff43e31e449dbc8e98f7580fea10b2ad1ad8278b3edcf5ff5b3a24b85cef3192fcd70452c58e7c968e500da9e290aefadf5ef22a4efbf0d',
+        '0xfd2e4b23a3e3f498664af355b341e833324276270a13f9647dd1f043248f92fccaa037d4cfc9d23f13a295f7d505ee13afb2b10cea548890678f9002947cbb0a',
       );
 
       await close();

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -6,6 +6,7 @@ import { add0x, assert, bytesToHex, remove0x } from '@metamask/utils';
 import { sign as signEd25519 } from '@noble/ed25519';
 import { sign as signSecp256k1 } from '@noble/secp256k1';
 import { serialize } from 'borsh';
+import { Uint64LE } from 'int64-buffer';
 
 import type { GetBip32PublicKeyParams, SignTransactionParams } from './types';
 
@@ -28,9 +29,11 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       });
 
     case 'signTransaction': {
-      const { schema, transaction, curve, ...params } =
+      const { schema, transaction, nonce, curve, ...params } =
         request.params as SignTransactionParams;
 
+      const nonceLe = new Uint64LE(nonce);
+      const nonceBytes = nonceLe.toBuffer();
       const serializedTransaction = serialize(schema, transaction);
 
       const json = await snap.request({
@@ -58,11 +61,11 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
           type: DialogType.Confirmation,
           content: panel([
             heading('Signature request'),
-            text(
-              `Do you want to ${curve} sign ${JSON.stringify(
-                transaction,
-              )} with the following public key?`,
-            ),
+            text(`Do you want to ${curve} sign`),
+            copyable(JSON.stringify(transaction)),
+            text(`with nonce`),
+            copyable(String(nonce)),
+            text(`and the following public key?`),
             copyable(add0x(node.publicKey)),
           ]),
         },
@@ -73,14 +76,18 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       }
 
       const privateKey = remove0x(node.privateKey);
+      const signedTransaction = new Uint8Array([
+        ...serializedTransaction,
+        ...nonceBytes,
+      ]);
 
       let signed;
       switch (curve) {
         case 'ed25519':
-          signed = await signEd25519(serializedTransaction, privateKey);
+          signed = await signEd25519(signedTransaction, privateKey);
           break;
         case 'secp256k1':
-          signed = await signSecp256k1(serializedTransaction, privateKey);
+          signed = await signSecp256k1(signedTransaction, privateKey);
           break;
         default:
           throw new Error(`Unsupported curve: ${String(curve)}.`);

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -2,17 +2,12 @@ import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import { DialogType, OnRpcRequestHandler } from '@metamask/snaps-types';
 import { copyable, heading, panel, text } from '@metamask/snaps-ui';
 import { SLIP10Node } from '@metamask/key-tree';
-import {
-  add0x,
-  assert,
-  bytesToHex,
-  remove0x,
-  valueToBytes,
-} from '@metamask/utils';
+import { add0x, assert, bytesToHex, remove0x } from '@metamask/utils';
 import { sign as signEd25519 } from '@noble/ed25519';
 import { sign as signSecp256k1 } from '@noble/secp256k1';
+import { serialize } from 'borsh';
 
-import type { GetBip32PublicKeyParams, SignMessageParams } from './types';
+import type { GetBip32PublicKeyParams, SignTransactionParams } from './types';
 
 /**
  * Handle incoming JSON-RPC requests, sent through `wallet_invokeSnap`.
@@ -32,8 +27,12 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
         params: request.params as unknown as GetBip32PublicKeyParams,
       });
 
-    case 'signMessage': {
-      const { message, curve, ...params } = request.params as SignMessageParams;
+    case 'signTransaction': {
+      const { schema, transaction, curve, ...params } =
+        request.params as SignTransactionParams;
+
+      const serializedTransaction = serialize(schema, transaction);
+
       const json = await snap.request({
         method: 'snap_getBip32Entropy',
         params: {
@@ -53,12 +52,6 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       assert(node.privateKey);
       assert(curve === 'ed25519' || curve === 'secp256k1');
 
-      // assert the user's approval of the provided message. Note: this message will be a raw bytes
-      // representation. A human-friendly format is currently not supported by the API as the
-      // conversion is expected to be performed before the interaction with the Snap.
-      //
-      // For more information, refer to the tracking issue:
-      // https://github.com/Sovereign-Labs/sovereign-sdk/issues/982
       const approved = await snap.request({
         method: 'snap_dialog',
         params: {
@@ -66,7 +59,9 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
           content: panel([
             heading('Signature request'),
             text(
-              `Do you want to ${curve} sign "${message}" with the following public key?`,
+              `Do you want to ${curve} sign ${JSON.stringify(
+                transaction,
+              )} with the following public key?`,
             ),
             copyable(add0x(node.publicKey)),
           ]),
@@ -77,16 +72,15 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
         throw providerErrors.userRejectedRequest();
       }
 
-      const messageBytes = valueToBytes(message);
       const privateKey = remove0x(node.privateKey);
 
       let signed;
       switch (curve) {
         case 'ed25519':
-          signed = await signEd25519(messageBytes, privateKey);
+          signed = await signEd25519(serializedTransaction, privateKey);
           break;
         case 'secp256k1':
-          signed = await signSecp256k1(messageBytes, privateKey);
+          signed = await signSecp256k1(serializedTransaction, privateKey);
           break;
         default:
           throw new Error(`Unsupported curve: ${String(curve)}.`);

--- a/packages/snap/src/types.ts
+++ b/packages/snap/src/types.ts
@@ -1,4 +1,4 @@
-import { Bytes } from '@metamask/utils';
+import { Schema } from 'borsh';
 
 /**
  * The parameters for calling the `getPublicKey` JSON-RPC method.
@@ -29,16 +29,21 @@ export type GetBip32PublicKeyParams = {
 };
 
 /**
- * The parameters for calling the `signMessage` JSON-RPC method.
+ * The parameters for calling the `signTransaction` JSON-RPC method.
  *
  * Note: For simplicity, these are not validated by the snap. In production, you
  * should validate that the request object matches this type before using it.
  */
-export type SignMessageParams = {
+export type SignTransactionParams = {
   /**
-   * The message to sign.
+   * The borsh schema of the transaction.
    */
-  message: Bytes;
+  schema: Schema;
+
+  /**
+   * The transaction to sign.
+   */
+  transaction: any;
 
   /**
    * The BIP-32 path to the account.

--- a/packages/snap/src/types.ts
+++ b/packages/snap/src/types.ts
@@ -46,11 +46,6 @@ export type SignTransactionParams = {
   transaction: any;
 
   /**
-   * The nonce of the transaction.
-   */
-  nonce: number;
-
-  /**
    * The BIP-32 path to the account.
    */
   path: string[];

--- a/packages/snap/src/types.ts
+++ b/packages/snap/src/types.ts
@@ -46,6 +46,11 @@ export type SignTransactionParams = {
   transaction: any;
 
   /**
+   * The nonce of the transaction.
+   */
+  nonce: number;
+
+  /**
    * The BIP-32 path to the account.
    */
   path: string[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -8378,6 +8378,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"borsh@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "borsh@npm:1.0.0"
+  checksum: fbb2101a30e94537a330b6158d513c497d760f4ddfc457e1431120a201f06eb05b7879100581e95deff07aad974cabc394da708a0be322ad26697177eadd123b
+  languageName: node
+  linkType: hard
+
 "boxen@npm:^4.2.0":
   version: 4.2.0
   resolution: "boxen@npm:4.2.0"
@@ -20827,6 +20834,7 @@ __metadata:
     "@types/styled-components": ^5.1.25
     "@typescript-eslint/eslint-plugin": ^5.33.0
     "@typescript-eslint/parser": ^5.33.0
+    borsh: ^1.0.0
     eslint: ^8.21.0
     eslint-config-prettier: ^8.1.0
     eslint-plugin-import: ^2.26.0
@@ -20871,6 +20879,7 @@ __metadata:
     "@noble/secp256k1": ^1.7.1
     "@typescript-eslint/eslint-plugin": ^5.33.0
     "@typescript-eslint/parser": ^5.33.0
+    borsh: ^1.0.0
     buffer: ^6.0.3
     eslint: ^8.21.0
     eslint-config-prettier: ^8.1.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -14277,13 +14277,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"int64-buffer@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "int64-buffer@npm:1.0.1"
-  checksum: 9962be285f4a0d6bd8f6fba3cffcfd80b15848af370bd9ec6cb2d9c8a8adf83b230cdf66b694f87c992c1a33724385b28ba7cac61602a7fcf9b9c8691015c7e2
-  languageName: node
-  linkType: hard
-
 "internal-slot@npm:^1.0.3":
   version: 1.0.3
   resolution: "internal-slot@npm:1.0.3"
@@ -20895,7 +20888,6 @@ __metadata:
     eslint-plugin-jsdoc: ^39.2.9
     eslint-plugin-node: ^11.1.0
     eslint-plugin-prettier: ^4.2.1
-    int64-buffer: ^1.0.1
     jest: ^29.5.0
     prettier: ^2.2.1
     prettier-plugin-packagejson: ^2.2.11

--- a/yarn.lock
+++ b/yarn.lock
@@ -14277,6 +14277,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"int64-buffer@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "int64-buffer@npm:1.0.1"
+  checksum: 9962be285f4a0d6bd8f6fba3cffcfd80b15848af370bd9ec6cb2d9c8a8adf83b230cdf66b694f87c992c1a33724385b28ba7cac61602a7fcf9b9c8691015c7e2
+  languageName: node
+  linkType: hard
+
 "internal-slot@npm:^1.0.3":
   version: 1.0.3
   resolution: "internal-slot@npm:1.0.3"
@@ -20888,6 +20895,7 @@ __metadata:
     eslint-plugin-jsdoc: ^39.2.9
     eslint-plugin-node: ^11.1.0
     eslint-plugin-prettier: ^4.2.1
+    int64-buffer: ^1.0.1
     jest: ^29.5.0
     prettier: ^2.2.1
     prettier-plugin-packagejson: ^2.2.11


### PR DESCRIPTION
This commit introduces borsh schema to define the serialization of a transaction.

The borsh serialized transaction is the one to be signed, as it is the same to be included on-chain.

The schema is always received as parameter so the snap remains stateless & functional.